### PR TITLE
skill: add-group-persona — per-group agent personas from WhatsApp group description

### DIFF
--- a/src/channels/whatsapp.test.ts
+++ b/src/channels/whatsapp.test.ts
@@ -6,6 +6,7 @@ import { EventEmitter } from 'events';
 // Mock config
 vi.mock('../config.js', () => ({
   STORE_DIR: '/tmp/nanoclaw-test-store',
+  GROUPS_DIR: '/tmp/nanoclaw-test-groups',
   ASSISTANT_NAME: 'Andy',
   ASSISTANT_HAS_OWN_NUMBER: false,
 }));
@@ -25,6 +26,7 @@ vi.mock('../db.js', () => ({
   getLastGroupSync: vi.fn(() => null),
   setLastGroupSync: vi.fn(),
   updateChatName: vi.fn(),
+  getRegisteredGroup: vi.fn(() => null),
 }));
 
 // Mock fs
@@ -36,6 +38,7 @@ vi.mock('fs', async () => {
       ...actual,
       existsSync: vi.fn(() => true),
       mkdirSync: vi.fn(),
+      writeFileSync: vi.fn(),
     },
   };
 });
@@ -100,7 +103,8 @@ vi.mock('@whiskeysockets/baileys', () => {
 });
 
 import { WhatsAppChannel, WhatsAppChannelOpts } from './whatsapp.js';
-import { getLastGroupSync, updateChatName, setLastGroupSync } from '../db.js';
+import { getLastGroupSync, updateChatName, setLastGroupSync, getRegisteredGroup } from '../db.js';
+import fs from 'fs';
 
 // --- Test helpers ---
 
@@ -863,6 +867,105 @@ describe('WhatsAppChannel', () => {
 
       expect(updateChatName).toHaveBeenCalledTimes(1);
       expect(updateChatName).toHaveBeenCalledWith('group1@g.us', 'Has Subject');
+    });
+  });
+
+  // --- Group persona ---
+
+  describe('group persona sync', () => {
+    beforeEach(() => {
+      vi.mocked(fs.writeFileSync).mockClear();
+      vi.mocked(getRegisteredGroup).mockReset();
+    });
+
+    it('writes group-persona.md when group has description and is registered', async () => {
+      fakeSocket.groupFetchAllParticipating.mockResolvedValue({
+        'group@g.us': { subject: 'Finance', desc: 'You are a finance assistant.' },
+      });
+      vi.mocked(getRegisteredGroup).mockReturnValue({
+        jid: 'group@g.us',
+        name: 'Finance',
+        folder: 'whatsapp_finance',
+        trigger: '@Andy',
+        requiresTrigger: true,
+        isMain: false,
+        added_at: '',
+        containerConfig: undefined,
+      });
+
+      const channel = new WhatsAppChannel(createTestOpts());
+      await connectChannel(channel);
+      await channel.syncGroupMetadata(true);
+
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        '/tmp/nanoclaw-test-groups/whatsapp_finance/group-persona.md',
+        'You are a finance assistant.',
+        'utf-8',
+      );
+    });
+
+    it('does not write group-persona.md when group has no description', async () => {
+      fakeSocket.groupFetchAllParticipating.mockResolvedValue({
+        'group@g.us': { subject: 'Finance' },
+      });
+      vi.mocked(getRegisteredGroup).mockReturnValue({
+        jid: 'group@g.us',
+        name: 'Finance',
+        folder: 'whatsapp_finance',
+        trigger: '@Andy',
+        requiresTrigger: true,
+        isMain: false,
+        added_at: '',
+        containerConfig: undefined,
+      });
+
+      const channel = new WhatsAppChannel(createTestOpts());
+      await connectChannel(channel);
+      await channel.syncGroupMetadata(true);
+
+      expect(fs.writeFileSync).not.toHaveBeenCalled();
+    });
+
+    it('does not write group-persona.md when group is not registered', async () => {
+      fakeSocket.groupFetchAllParticipating.mockResolvedValue({
+        'group@g.us': { subject: 'Finance', desc: 'You are a finance assistant.' },
+      });
+      vi.mocked(getRegisteredGroup).mockReturnValue(undefined);
+
+      const channel = new WhatsAppChannel(createTestOpts());
+      await connectChannel(channel);
+      await channel.syncGroupMetadata(true);
+
+      expect(fs.writeFileSync).not.toHaveBeenCalled();
+    });
+
+    it('writes persona files for multiple registered groups independently', async () => {
+      fakeSocket.groupFetchAllParticipating.mockResolvedValue({
+        'group1@g.us': { subject: 'Finance', desc: 'Finance assistant.' },
+        'group2@g.us': { subject: 'Travel', desc: 'Travel planner.' },
+      });
+      vi.mocked(getRegisteredGroup).mockImplementation((jid) => {
+        if (jid === 'group1@g.us') return { jid, name: 'Finance', folder: 'finance', trigger: '@Andy', requiresTrigger: true, isMain: false, added_at: '' };
+        if (jid === 'group2@g.us') return { jid, name: 'Travel', folder: 'travel', trigger: '@Andy', requiresTrigger: true, isMain: false, added_at: '' };
+        return undefined;
+      });
+
+      const channel = new WhatsAppChannel(createTestOpts());
+      await connectChannel(channel);
+      vi.mocked(fs.writeFileSync).mockClear();
+      await channel.syncGroupMetadata(true);
+
+      expect(fs.writeFileSync).toHaveBeenCalledTimes(2);
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        '/tmp/nanoclaw-test-groups/finance/group-persona.md',
+        'Finance assistant.',
+        'utf-8',
+      );
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        '/tmp/nanoclaw-test-groups/travel/group-persona.md',
+        'Travel planner.',
+        'utf-8',
+      );
     });
   });
 

--- a/src/channels/whatsapp.ts
+++ b/src/channels/whatsapp.ts
@@ -15,9 +15,10 @@ import makeWASocket, {
 import {
   ASSISTANT_HAS_OWN_NUMBER,
   ASSISTANT_NAME,
+  GROUPS_DIR,
   STORE_DIR,
 } from '../config.js';
-import { getLastGroupSync, setLastGroupSync, updateChatName } from '../db.js';
+import { getLastGroupSync, getRegisteredGroup, setLastGroupSync, updateChatName } from '../db.js';
 import { logger } from '../logger.js';
 import {
   Channel,
@@ -329,6 +330,16 @@ export class WhatsAppChannel implements Channel {
         if (metadata.subject) {
           updateChatName(jid, metadata.subject);
           count++;
+        }
+
+        // Sync group description → group-persona.md for per-group agent persona
+        if (metadata.desc) {
+          const group = getRegisteredGroup(jid);
+          if (group) {
+            const personaPath = path.join(GROUPS_DIR, group.folder, 'group-persona.md');
+            fs.writeFileSync(personaPath, metadata.desc, 'utf-8');
+            logger.debug({ jid, folder: group.folder }, 'Updated group-persona.md from WhatsApp description');
+          }
         }
       }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import path from 'path';
 import {
   ASSISTANT_NAME,
   CREDENTIAL_PROXY_PORT,
+  GROUPS_DIR,
   IDLE_TIMEOUT,
   POLL_INTERVAL,
   TIMEZONE,
@@ -175,7 +176,12 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
     if (!hasTrigger) return true;
   }
 
-  const prompt = formatMessages(missedMessages, TIMEZONE);
+  const rawPrompt = formatMessages(missedMessages, TIMEZONE);
+  const personaPath = path.join(GROUPS_DIR, group.folder, 'group-persona.md');
+  const personaPrefix = fs.existsSync(personaPath)
+    ? `<group_persona>\n${fs.readFileSync(personaPath, 'utf-8').trim()}\n</group_persona>\n\n`
+    : '';
+  const prompt = personaPrefix + rawPrompt;
 
   // Advance cursor so the piping path in startMessageLoop won't re-fetch
   // these messages. Save the old cursor so we can roll back on error.


### PR DESCRIPTION
Adds a `skill/group-persona` branch for the `/add-group-persona` skill.

## What it does

Uses the WhatsApp group description as the agent's system prompt for that group. Set the description in WhatsApp and the agent in that group adopts that personality — finance assistant, travel planner, work agent — no config files, no restart.

## Changes in this branch

- `src/channels/whatsapp.ts` — syncs `metadata.desc` to `groups/{folder}/group-persona.md` inside the existing `syncGroupMetadata` loop (field already fetched by Baileys, just unused)
- `src/channels/whatsapp.test.ts` — 4 tests: write on sync, no-op when no desc, no-op when group not registered, independent writes for multiple groups
- `src/index.ts` — prepends `<group_persona>` block to agent prompt when file exists

## Persistence

`group-persona.md` lives on the host filesystem outside Docker. Survives container and daemon restarts. Re-synced from WhatsApp on each 24h metadata cycle.

## Related

Skill PR on qwibitai/nanoclaw: https://github.com/qwibitai/nanoclaw/pull/1292