### PR TITLE
skill/whats-app-files: WhatsApp media attachment download

### DIFF
--- a/.claude/skills/add-whatsapp-files/SKILL.md
+++ b/.claude/skills/add-whatsapp-files/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: add-whatsapp-files
+description: Add WhatsApp file attachment support — automatically download and save incoming media, images, documents, audio, and video so agents can read them.
+---
+
+# Add WhatsApp Files
+
+This skill adds media attachment handling to NanoClaw's WhatsApp channel. When a user sends a file, image, video, audio, or document, it is automatically downloaded and saved to the group's `uploads/` directory before the agent runs. The agent receives the file path as part of the message content.
+
+## Phase 1: Pre-flight
+
+### Check if already applied
+
+```bash
+grep -q 'MIME_TO_EXT' src/channels/whatsapp.ts && echo "Already applied" || echo "Not applied"
+```
+
+If already applied, skip to Phase 3 (Verify).
+
+## Phase 2: Apply Code Changes
+
+### Ensure WhatsApp fork remote
+
+```bash
+git remote -v
+```
+
+If `whatsapp` is missing, add it:
+
+```bash
+git remote add whatsapp https://github.com/qwibitai/nanoclaw-whatsapp.git
+```
+
+### Merge the skill branch
+
+```bash
+git fetch whatsapp skill/whats-app-files
+git merge whatsapp/skill/whats-app-files || {
+  git checkout --theirs package-lock.json
+  git add package-lock.json
+  git merge --continue
+}
+```
+
+This adds:
+- `container/skills/whatsapp-files/SKILL.md` (agent-facing documentation explaining how attachments appear in messages)
+- Media download logic in `src/channels/whatsapp.ts`: detects images, video, audio, documents, and stickers; downloads them to `groups/{folder}/uploads/`; appends `[attachment: /workspace/group/uploads/{filename}]` to the message content
+
+### Validate code changes
+
+```bash
+npm test
+npm run build
+```
+
+All tests must pass and build must be clean before proceeding.
+
+## Phase 3: Verify
+
+### Build and restart
+
+```bash
+npm run build
+```
+
+Linux:
+```bash
+systemctl --user restart nanoclaw
+```
+
+macOS:
+```bash
+launchctl kickstart -k gui/$(id -u)/com.nanoclaw
+```
+
+### Test file attachments
+
+1. Send an image or document to your registered WhatsApp group
+2. Check the uploads directory for the downloaded file:
+
+```bash
+ls groups/*/uploads/
+```
+
+3. Ask the agent to describe the file — it should reference the path and be able to read it
+
+### Verify agent sees attachment
+
+The agent's message content should include something like:
+
+```
+[attachment: /workspace/group/uploads/3EB0C123456789AB.jpg]
+```
+
+## Troubleshooting
+
+### File not appearing in uploads/
+
+- Check NanoClaw logs for `Failed to download media` errors
+- Verify the WhatsApp channel is connected
+- Ensure the group is registered — attachments are only downloaded for registered groups
+
+### Agent receives path but file is empty or missing
+
+- The download may have failed silently; check logs for `Failed to download media` with the error detail
+- WhatsApp media links expire — if the message is old, re-send the file
+
+### Conflicts when merging with skill/reactions
+
+If both `skill/whats-app-files` and `skill/reactions` are being merged, conflicts will appear in `src/channels/whatsapp.ts`. Resolve by keeping both the media download block and the reaction event handler — they operate in different event listeners.

--- a/container/skills/whatsapp-files/SKILL.md
+++ b/container/skills/whatsapp-files/SKILL.md
@@ -1,0 +1,34 @@
+# WhatsApp File Attachments
+
+When someone sends you a file, image, video, audio, or document via WhatsApp, it is automatically downloaded and saved to your group's `uploads/` folder before your turn starts.
+
+## How attachments appear
+
+The message content will include a reference like:
+
+```
+[attachment: /workspace/group/uploads/3EB0C123456789AB.jpg]
+```
+
+For documents with a filename:
+
+```
+[attachment: /workspace/group/uploads/3EB0C123456789AB_report.pdf]
+```
+
+## Reading attachments
+
+The path is a real file on your filesystem. Use standard tools to read it:
+
+- **Images/PDFs**: Use your browser tool or `cat` a converted form
+- **Text files**: Read directly with `cat` or the Read tool
+- **PDF**: Use `pdftotext` if the pdf-reader skill is installed, otherwise note it requires a reader
+- **Audio/Video**: Note the file exists and describe it by type; you cannot play it but can describe metadata
+
+## Supported types
+
+Images (jpg, png, gif, webp, heic), Video (mp4, 3gp, mov), Audio (ogg, mp3, m4a, aac, wav), Documents (pdf, docx, xlsx, pptx, txt, zip), and others (saved as `.bin`).
+
+## File naming
+
+Files are named `{messageId}.{ext}` or `{messageId}_{originalFilename}` for documents. They persist across sessions in the group's uploads directory.

--- a/src/channels/whatsapp.ts
+++ b/src/channels/whatsapp.ts
@@ -6,6 +6,7 @@ import makeWASocket, {
   Browsers,
   DisconnectReason,
   WASocket,
+  downloadMediaMessage,
   fetchLatestWaWebVersion,
   makeCacheableSignalKeyStore,
   normalizeMessageContent,
@@ -19,6 +20,7 @@ import {
 } from '../config.js';
 import { getLastGroupSync, setLastGroupSync, updateChatName } from '../db.js';
 import { logger } from '../logger.js';
+import { resolveGroupFolderPath } from '../group-folder.js';
 import {
   Channel,
   OnInboundMessage,
@@ -28,6 +30,42 @@ import {
 import { registerChannel, ChannelOpts } from './registry.js';
 
 const GROUP_SYNC_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+// Map mimetype prefixes to file extensions
+const MIME_TO_EXT: Record<string, string> = {
+  'image/jpeg': 'jpg',
+  'image/jpg': 'jpg',
+  'image/png': 'png',
+  'image/gif': 'gif',
+  'image/webp': 'webp',
+  'image/heic': 'heic',
+  'video/mp4': 'mp4',
+  'video/3gpp': '3gp',
+  'video/quicktime': 'mov',
+  'audio/ogg': 'ogg',
+  'audio/mpeg': 'mp3',
+  'audio/mp4': 'm4a',
+  'audio/aac': 'aac',
+  'audio/wav': 'wav',
+  'application/pdf': 'pdf',
+  'application/zip': 'zip',
+  'application/x-zip-compressed': 'zip',
+  'text/plain': 'txt',
+  'application/msword': 'doc',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document':
+    'docx',
+  'application/vnd.ms-excel': 'xls',
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': 'xlsx',
+  'application/vnd.ms-powerpoint': 'ppt',
+  'application/vnd.openxmlformats-officedocument.presentationml.presentation':
+    'pptx',
+};
+
+function extFromMime(mimetype: string | null | undefined): string {
+  if (!mimetype) return 'bin';
+  const base = mimetype.split(';')[0].trim().toLowerCase();
+  return MIME_TO_EXT[base] ?? base.split('/')[1] ?? 'bin';
+}
 
 export interface WhatsAppChannelOpts {
   onMessage: OnInboundMessage;
@@ -202,16 +240,71 @@ export class WhatsAppChannel implements Channel {
 
           // Only deliver full message for registered groups
           const groups = this.opts.registeredGroups();
-          if (groups[chatJid]) {
-            const content =
+          const group = groups[chatJid];
+          if (group) {
+            const textContent =
               normalized.conversation ||
               normalized.extendedTextMessage?.text ||
               normalized.imageMessage?.caption ||
               normalized.videoMessage?.caption ||
+              normalized.documentMessage?.caption ||
               '';
 
-            // Skip protocol messages with no text content (encryption keys, read receipts, etc.)
-            if (!content) continue;
+            // Detect and download media attachments
+            const mediaMsg =
+              normalized.imageMessage ||
+              normalized.videoMessage ||
+              normalized.audioMessage ||
+              normalized.documentMessage ||
+              normalized.stickerMessage;
+
+            let attachmentRef = '';
+            if (mediaMsg) {
+              try {
+                const groupDir = resolveGroupFolderPath(group.folder);
+                const uploadsDir = path.join(groupDir, 'uploads');
+                fs.mkdirSync(uploadsDir, { recursive: true });
+
+                const mimetype =
+                  (mediaMsg as { mimetype?: string }).mimetype ?? null;
+                const originalFilename =
+                  (normalized.documentMessage?.fileName as
+                    | string
+                    | undefined) ?? null;
+                const ext = originalFilename
+                  ? path.extname(originalFilename).replace(/^\./, '') ||
+                    extFromMime(mimetype)
+                  : extFromMime(mimetype);
+                const msgId = msg.key.id ?? Date.now().toString();
+                const basename = originalFilename
+                  ? `${msgId}_${path.basename(originalFilename)}`
+                  : `${msgId}.${ext}`;
+                const filePath = path.join(uploadsDir, basename);
+
+                const buffer = await downloadMediaMessage(
+                  msg,
+                  'buffer',
+                  {},
+                  { logger, reuploadRequest: this.sock.updateMediaMessage },
+                );
+                fs.writeFileSync(filePath, buffer as Buffer);
+
+                // Container sees this path as /workspace/group/uploads/{basename}
+                const containerPath = `/workspace/group/uploads/${basename}`;
+                attachmentRef = ` [attachment: ${containerPath}]`;
+                logger.info(
+                  { basename, mimetype, chatJid },
+                  'Media file saved to uploads',
+                );
+              } catch (err) {
+                logger.warn({ err, chatJid }, 'Failed to download media');
+              }
+            }
+
+            const content = textContent + attachmentRef;
+
+            // Skip protocol messages with no text content and no attachment
+            if (!content.trim()) continue;
 
             const sender = msg.key.participant || msg.key.remoteJid || '';
             const senderName = msg.pushName || sender.split('@')[0];


### PR DESCRIPTION
## Summary

- Automatically downloads incoming WhatsApp media (images, video, audio, documents, stickers) to `groups/{folder}/uploads/` before the agent runs
- Appends `[attachment: /workspace/group/uploads/{filename}]` to message content so agents can read files directly
- Documents preserve original filename as `{messageId}_{filename}`; other media uses `{messageId}.{ext}`
- Download failures log a warning but don't drop the message

## Changes

- `src/channels/whatsapp.ts` — adds `downloadMediaMessage`, `MIME_TO_EXT` map, `extFromMime()`, and the download block in the `messages.upsert` handler
- `container/skills/whatsapp-files/SKILL.md` — agent-facing docs explaining how attachments appear in messages
- `.claude/skills/add-whatsapp-files/SKILL.md` — user-facing installer (pre-flight, merge, validate, verify, troubleshoot)

## Test plan

- [ ] Send an image to a registered WhatsApp group — check `groups/*/uploads/` for the downloaded file
- [ ] Ask the agent to describe the image — it should reference the path and read the file
- [ ] Send a PDF with a filename — verify `{messageId}_{filename}` naming in uploads
- [ ] Send a voice note — verify it saves as `.ogg`
- [ ] Send a text-only message — verify no download is attempted and message routes normally
- [ ] Verify `Failed to download media` is logged (not thrown) when download fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)