### PR TITLE
feat: Preserve original resolution images alongside resized

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -365,6 +365,7 @@ async function runQuery(
   // Load image attachments and send as multimodal content blocks
   if (containerInput.imageAttachments?.length) {
     const blocks: ContentBlock[] = [];
+    const originalPaths: string[] = [];
     for (const img of containerInput.imageAttachments) {
       const imgPath = path.join('/workspace/group', img.relativePath);
       try {
@@ -373,9 +374,18 @@ async function runQuery(
       } catch (err) {
         log(`Failed to load image: ${imgPath}`);
       }
+      if (img.originalRelativePath) {
+        originalPaths.push(path.join('/workspace/group', img.originalRelativePath));
+      }
     }
     if (blocks.length > 0) {
       stream.pushMultimodal(blocks);
+    }
+    if (originalPaths.length > 0) {
+      stream.push(
+        `Original high-resolution image${originalPaths.length > 1 ? 's' : ''} available at:\n` +
+          originalPaths.map((p) => `- ${p}`).join('\n'),
+      );
     }
   }
 

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -41,8 +41,7 @@ export interface ContainerInput {
   isMain: boolean;
   isScheduledTask?: boolean;
   assistantName?: string;
-  imageAttachments?: Array<{ relativePath: string; mediaType: string }>;
-
+  imageAttachments?: Array<{ relativePath: string; mediaType: string; originalRelativePath: string }>;
 }
 
 export interface ContainerOutput {

--- a/src/image.ts
+++ b/src/image.ts
@@ -4,16 +4,28 @@ import sharp from 'sharp';
 import type { WAMessage } from '@whiskeysockets/baileys';
 
 const MAX_DIMENSION = 1024;
-const IMAGE_REF_PATTERN = /\[Image: (attachments\/[^\]]+)\]/g;
+const IMAGE_REF_PATTERN =
+  /\[Image: (attachments\/[^\]\s]+)(?:\s+original:(attachments\/[^\]]+))?\]/g;
+
+const FORMAT_TO_EXT: Record<string, string> = {
+  jpeg: 'jpg',
+  png: 'png',
+  webp: 'webp',
+  gif: 'gif',
+  tiff: 'tiff',
+  avif: 'avif',
+};
 
 export interface ProcessedImage {
   content: string;
   relativePath: string;
+  originalRelativePath: string;
 }
 
 export interface ImageAttachment {
   relativePath: string;
   mediaType: string;
+  originalRelativePath: string;
 }
 
 export function isImageMessage(msg: WAMessage): boolean {
@@ -27,24 +39,33 @@ export async function processImage(
 ): Promise<ProcessedImage | null> {
   if (!buffer || buffer.length === 0) return null;
 
+  const attachDir = path.join(groupDir, 'attachments');
+  fs.mkdirSync(attachDir, { recursive: true });
+
+  const stem = `img-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+
+  // Detect original format and save at full resolution
+  const metadata = await sharp(buffer).metadata();
+  const origExt = FORMAT_TO_EXT[metadata.format ?? ''] ?? 'jpg';
+  const originalFilename = `${stem}-original.${origExt}`;
+  fs.writeFileSync(path.join(attachDir, originalFilename), buffer);
+
+  // Save resized version for Claude prompt
   const resized = await sharp(buffer)
     .resize(MAX_DIMENSION, MAX_DIMENSION, { fit: 'inside', withoutEnlargement: true })
     .jpeg({ quality: 85 })
     .toBuffer();
 
-  const attachDir = path.join(groupDir, 'attachments');
-  fs.mkdirSync(attachDir, { recursive: true });
+  const resizedFilename = `${stem}.jpg`;
+  fs.writeFileSync(path.join(attachDir, resizedFilename), resized);
 
-  const filename = `img-${Date.now()}-${Math.random().toString(36).slice(2, 6)}.jpg`;
-  const filePath = path.join(attachDir, filename);
-  fs.writeFileSync(filePath, resized);
-
-  const relativePath = `attachments/${filename}`;
+  const relativePath = `attachments/${resizedFilename}`;
+  const originalRelativePath = `attachments/${originalFilename}`;
   const content = caption
-    ? `[Image: ${relativePath}] ${caption}`
-    : `[Image: ${relativePath}]`;
+    ? `[Image: ${relativePath} original:${originalRelativePath}] ${caption}`
+    : `[Image: ${relativePath} original:${originalRelativePath}]`;
 
-  return { content, relativePath };
+  return { content, relativePath, originalRelativePath };
 }
 
 export function parseImageReferences(
@@ -55,8 +76,11 @@ export function parseImageReferences(
     let match: RegExpExecArray | null;
     IMAGE_REF_PATTERN.lastIndex = 0;
     while ((match = IMAGE_REF_PATTERN.exec(msg.content)) !== null) {
-      // Always JPEG — processImage() normalizes all images to .jpg
-      refs.push({ relativePath: match[1], mediaType: 'image/jpeg' });
+      refs.push({
+        relativePath: match[1],
+        mediaType: 'image/jpeg',
+        originalRelativePath: match[2] || match[1],
+      });
     }
   }
   return refs;

--- a/src/index.ts
+++ b/src/index.ts
@@ -265,7 +265,7 @@ async function runAgent(
   group: RegisteredGroup,
   prompt: string,
   chatJid: string,
-  imageAttachments: Array<{ relativePath: string; mediaType: string }>,
+  imageAttachments: Array<{ relativePath: string; mediaType: string; originalRelativePath: string }>,
   onOutput?: (output: ContainerOutput) => Promise<void>,
 ): Promise<'success' | 'error'> {
   const isMain = group.isMain === true;


### PR DESCRIPTION
## Summary

- Save both the **original** (full resolution, native format) and **resized** (max 1024px JPEG) versions of incoming images
- The resized image is sent to Claude as the multimodal content block (unchanged behavior)
- The agent is informed of the original file path and can use it for downstream workflows (e.g. passing to Gemini, saving to cloud storage)
- Original format detected via sharp metadata and preserved (PNG stays PNG, WebP stays WebP, etc.)

Closes #54

### File naming convention

```
attachments/
  img-1711234567890-abc1.jpg              # resized (max 1024px, JPEG 85%)
  img-1711234567890-abc1-original.png     # original resolution, original format
```

### Files changed

- `src/image.ts` — save original buffer alongside resized; detect format via sharp; update interfaces and regex parser
- `src/index.ts` — pass `originalRelativePath` through pipeline
- `src/container-runner.ts` — add `originalRelativePath` to `ContainerInput` type
- `container/agent-runner/src/index.ts` — inform agent of original file paths via text after multimodal blocks

## Test plan

- [ ] Send an image via WhatsApp
- [ ] Verify both `img-*-.jpg` and `img-*-original.*` exist in `attachments/`
- [ ] Verify agent receives resized image in Claude prompt (multimodal block)
- [ ] Verify agent prompt text mentions original file path
- [ ] Ask agent to send back the original — confirm it references the `-original` file
- [ ] Test with different formats (PNG, WebP, JPEG) — originals should keep their format

🤖 Generated with [Claude Code](https://claude.com/claude-code)