### PR TITLE
fix: translate sender LID JIDs and @mentions in message content

### DIFF
--- a/src/channels/whatsapp.ts
+++ b/src/channels/whatsapp.ts
@@ -203,7 +203,7 @@ export class WhatsAppChannel implements Channel {
           // Only deliver full message for registered groups
           const groups = this.opts.registeredGroups();
           if (groups[chatJid]) {
-            const content =
+            let content =
               normalized.conversation ||
               normalized.extendedTextMessage?.text ||
               normalized.imageMessage?.caption ||
@@ -213,7 +213,20 @@ export class WhatsAppChannel implements Channel {
             // Skip protocol messages with no text content (encryption keys, read receipts, etc.)
             if (!content) continue;
 
-            const sender = msg.key.participant || msg.key.remoteJid || '';
+            // WhatsApp replaces @mentions with the user's internal LID/phone number.
+            // Translate bot mentions back to @AssistantName so trigger patterns match.
+            if (this.sock.user) {
+              const phoneUser = this.sock.user.id.split(':')[0];
+              const lidUser = this.sock.user.lid?.split(':')[0];
+              const mentionPattern = new RegExp(
+                `@(${phoneUser}${lidUser ? '|' + lidUser : ''})\\b`,
+                'g',
+              );
+              content = content.replace(mentionPattern, `@${ASSISTANT_NAME}`);
+            }
+
+            const rawSender = msg.key.participant || msg.key.remoteJid || '';
+            const sender = await this.translateJid(rawSender);
             const senderName = msg.pushName || sender.split('@')[0];
 
             const fromMe = msg.key.fromMe || false;


### PR DESCRIPTION

## Type of Change

- [ ] **Skill** - adds a new skill in `.claude/skills/`
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code

## Description

Two places in ⁠ whatsapp.ts ⁠ where ⁠ translateJid() ⁠ should be called but isn't, causing the bot to silently ignore messages in group chats:

1.⁠ ⁠*Sender JID* — ⁠ msg.key.participant ⁠ can be a ⁠ @lid ⁠ JID. The raw value fails sender allowlist matching since the allowlist uses phone-based JIDs. Fix: call ⁠ translateJid() ⁠ on the sender before storing.

2.⁠ ⁠*@mentions* — WhatsApp replaces ⁠ @Andy ⁠ with the user's internal LID/phone number (e.g. ⁠ @12345678 ⁠). The trigger pattern never matches. Fix: regex-replace bot phone/LID mentions back to ⁠ @AssistantName ⁠.

⁠ translateJid() ⁠ already exists (PR #62, issue #185) — this PR ensures it's applied in two missed call sites.


## For Skills

- [ ] I have not made any changes to source code
- [ ] My skill contains instructions for Claude to follow (not pre-built code)
- [ ] I tested this skill on a fresh clone
