### PR TITLE
fix: pass participant in status tracker reactions for group chats

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -192,7 +192,7 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
   // directly via the queue, bypassing startMessageLoop where markReceived normally fires.
   // markReceived is idempotent (rejects duplicates), so this is safe for normal-path messages too.
   for (const msg of missedMessages) {
-    statusTracker.markReceived(msg.id, chatJid, false);
+    statusTracker.markReceived(msg.id, chatJid, false, msg.sender);
   }
 
   // Mark all user messages as thinking (container is spawning)
@@ -460,7 +460,7 @@ async function startMessageLoop(): Promise<void> {
           // Mark each user message as received (status emoji)
           for (const msg of groupMessages) {
             if (!msg.is_from_me && !msg.is_bot_message) {
-              statusTracker.markReceived(msg.id, chatJid, false);
+              statusTracker.markReceived(msg.id, chatJid, false, msg.sender);
             }
           }
 

--- a/src/status-tracker.ts
+++ b/src/status-tracker.ts
@@ -27,12 +27,14 @@ interface MessageKey {
   id: string;
   remoteJid: string;
   fromMe?: boolean;
+  participant?: string;
 }
 
 interface TrackedMessage {
   messageId: string;
   chatJid: string;
   fromMe: boolean;
+  participant?: string;
   state: number;
   terminal: 'done' | 'failed' | null;
   sendChain: Promise<void>;
@@ -43,6 +45,7 @@ interface PersistedEntry {
   messageId: string;
   chatJid: string;
   fromMe: boolean;
+  participant?: string;
   state: number;
   terminal: 'done' | 'failed' | null;
   trackedAt: number;
@@ -70,7 +73,12 @@ export class StatusTracker {
     this.persistPath = path.join(DATA_DIR, 'status-tracker.json');
   }
 
-  markReceived(messageId: string, chatJid: string, fromMe: boolean): boolean {
+  markReceived(
+    messageId: string,
+    chatJid: string,
+    fromMe: boolean,
+    participant?: string,
+  ): boolean {
     if (!this.deps.isMainGroup(chatJid)) return false;
     if (this.tracked.has(messageId)) return false;
 
@@ -78,6 +86,7 @@ export class StatusTracker {
       messageId,
       chatJid,
       fromMe,
+      participant,
       state: StatusState.RECEIVED,
       terminal: null,
       sendChain: Promise.resolve(),
@@ -170,6 +179,7 @@ export class StatusTracker {
         messageId: entry.messageId,
         chatJid: entry.chatJid,
         fromMe: entry.fromMe,
+        participant: entry.participant,
         state: entry.state,
         terminal: null,
         sendChain: Promise.resolve(),
@@ -264,6 +274,7 @@ export class StatusTracker {
       id: msg.messageId,
       remoteJid: msg.chatJid,
       fromMe: msg.fromMe,
+      participant: msg.participant,
     };
     msg.sendChain = msg.sendChain.then(async () => {
       for (let attempt = 1; attempt <= REACTION_MAX_RETRIES; attempt++) {
@@ -302,6 +313,7 @@ export class StatusTracker {
           messageId: msg.messageId,
           chatJid: msg.chatJid,
           fromMe: msg.fromMe,
+          participant: msg.participant,
           state: msg.state,
           terminal: msg.terminal,
           trackedAt: msg.trackedAt,


### PR DESCRIPTION
## Type of Change

- [x] **Fix** - bug fix or security fix to source code

## Description

WhatsApp group reactions require the sender's JID as participant in the message key. Without it, status reactions (eyes, thinking, checkmark) silently fail in group chats while working fine in 1:1 chats.

- Add participant field to MessageKey, TrackedMessage, PersistedEntry
- Pass sender as participant in markReceived calls
- Include participant in reaction message key and persist/recover