### PR TITLE
fix: patch Baileys 6.x getPlatformId bug for pairing codes

### DIFF
--- a/src/channels/whatsapp.ts
+++ b/src/channels/whatsapp.ts
@@ -16,6 +16,19 @@ import type { GroupMetadata, WAMessageKey, WASocket, proto as ProtoTypes } from 
 import { createRequire } from 'module';
 const { proto } = createRequire(import.meta.url)('@whiskeysockets/baileys') as { proto: typeof ProtoTypes };
 
+// TODO: Migrate to Baileys 7.x and remove this monkey-patch.
+// Fix Baileys 6.x bug: getPlatformId sends charCode (49) instead of enum value (1).
+// Fixed in Baileys 7.x but not backported. Without this, pairing codes fail with
+// "couldn't link device" because WhatsApp receives an invalid platform ID.
+import * as generics from '@whiskeysockets/baileys/lib/Utils/generics.js';
+(generics as any).getPlatformId = (browser: string): string => {
+  const platformType =
+    proto.DeviceProps.PlatformType[
+      browser.toUpperCase() as keyof typeof proto.DeviceProps.PlatformType
+    ];
+  return platformType ? platformType.toString() : '1';
+};
+
 import {
   ASSISTANT_HAS_OWN_NUMBER,
   ASSISTANT_NAME,


### PR DESCRIPTION
Baileys 6.x getPlatformId sends charCode (49) instead of enum value (1), causing "couldn't link device" errors during pairing. Monkey-patch the function until we migrate to Baileys 7.x where this is fixed upstream.

<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description


## For Skills

- [ ] SKILL.md contains instructions, not inline code (code goes in separate files)
- [ ] SKILL.md is under 500 lines
- [ ] I tested this skill on a fresh clone
