### PR TITLE
fix: move getPlatformId patch to whatsapp-auth.ts

### DIFF
--- a/src/channels/whatsapp.ts
+++ b/src/channels/whatsapp.ts
@@ -23,22 +23,6 @@ const { proto } = createRequire(import.meta.url)('@whiskeysockets/baileys') as {
   proto: typeof ProtoTypes;
 };
 
-// TODO: Migrate to Baileys 7.x and remove this monkey-patch.
-// Fix Baileys 6.x bug: getPlatformId sends charCode (49) instead of enum value (1).
-// Fixed in Baileys 7.x but not backported. Without this, pairing codes fail with
-// "couldn't link device" because WhatsApp receives an invalid platform ID.
-// NOTE: Must use createRequire — ESM `import *` creates a read-only namespace.
-const _generics = createRequire(import.meta.url)(
-  '@whiskeysockets/baileys/lib/Utils/generics',
-) as Record<string, unknown>;
-_generics.getPlatformId = (browser: string): string => {
-  const platformType =
-    proto.DeviceProps.PlatformType[
-      browser.toUpperCase() as keyof typeof proto.DeviceProps.PlatformType
-    ];
-  return platformType ? platformType.toString() : '1';
-};
-
 import {
   ASSISTANT_HAS_OWN_NUMBER,
   ASSISTANT_NAME,

--- a/src/whatsapp-auth.ts
+++ b/src/whatsapp-auth.ts
@@ -20,7 +20,25 @@ import {
   fetchLatestWaWebVersion,
   makeCacheableSignalKeyStore,
   useMultiFileAuthState,
+  proto,
 } from '@whiskeysockets/baileys';
+
+// Fix Baileys 6.x bug: getPlatformId sends charCode (49) instead of enum value (1).
+// Fixed in Baileys 7.x but not backported. Without this, pairing codes fail with
+// "couldn't link device" because WhatsApp receives an invalid platform ID.
+// NOTE: Must use createRequire — ESM `import *` creates a read-only namespace.
+import { createRequire } from 'module';
+const _require = createRequire(import.meta.url);
+const _generics = _require(
+  '@whiskeysockets/baileys/lib/Utils/generics',
+) as Record<string, unknown>;
+_generics.getPlatformId = (browser: string): string => {
+  const platformType =
+    proto.DeviceProps.PlatformType[
+      browser.toUpperCase() as keyof typeof proto.DeviceProps.PlatformType
+    ];
+  return platformType ? platformType.toString() : '1';
+};
 
 const AUTH_DIR = './store/auth';
 const QR_FILE = './store/qr-data.txt';


### PR DESCRIPTION
## Summary
- Remove getPlatformId monkey-patch from `src/channels/whatsapp.ts` (runtime channel — not where pairing runs)
- Add it to `src/whatsapp-auth.ts` where the pairing code flow actually executes

## Test plan
- [ ] Pair a new device using pairing code and confirm it connects successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)