### PR TITLE
fix: import proto via createRequire, not ESM

### DIFF
--- a/src/whatsapp-auth.ts
+++ b/src/whatsapp-auth.ts
@@ -20,7 +20,6 @@ import {
   fetchLatestWaWebVersion,
   makeCacheableSignalKeyStore,
   useMultiFileAuthState,
-  proto,
 } from '@whiskeysockets/baileys';
 
 // Fix Baileys 6.x bug: getPlatformId sends charCode (49) instead of enum value (1).
@@ -32,6 +31,7 @@ const _require = createRequire(import.meta.url);
 const _generics = _require(
   '@whiskeysockets/baileys/lib/Utils/generics',
 ) as Record<string, unknown>;
+const { proto } = _require('@whiskeysockets/baileys') as { proto: any };
 _generics.getPlatformId = (browser: string): string => {
   const platformType =
     proto.DeviceProps.PlatformType[


### PR DESCRIPTION
## Summary
- `proto` is not a named ESM export from Baileys 6.x (CJS module) — the ESM import crashes before the getPlatformId patch takes effect
- Import `proto` via `createRequire` alongside the generics patch

## Test plan
- [ ] Pair a new device using pairing code — should connect without "couldn't link device" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)