### PR TITLE
fix: stop suppressing phone notifications on connect

### DIFF
--- a/src/channels/whatsapp.test.ts
+++ b/src/channels/whatsapp.test.ts
@@ -167,6 +167,21 @@ describe('WhatsAppChannel', () => {
     return p;
   }
 
+  // --- Notification suppression ---
+
+  describe('notification suppression', () => {
+    it('passes markOnlineOnConnect: false to makeWASocket', async () => {
+      const opts = createTestOpts();
+      const channel = new WhatsAppChannel(opts);
+      await connectChannel(channel);
+
+      const { makeWASocket } = await import('@whiskeysockets/baileys');
+      expect(makeWASocket).toHaveBeenCalledWith(
+        expect.objectContaining({ markOnlineOnConnect: false }),
+      );
+    });
+  });
+
   // --- Version fetch ---
 
   describe('version fetch', () => {

--- a/src/channels/whatsapp.ts
+++ b/src/channels/whatsapp.ts
@@ -111,6 +111,7 @@ export class WhatsAppChannel implements Channel {
       printQRInTerminal: false,
       logger: baileysLogger,
       browser: Browsers.macOS('Chrome'),
+      markOnlineOnConnect: false,
       cachedGroupMetadata: async (jid: string) =>
         this.getNormalizedGroupMetadata(jid),
       getMessage: async (key: WAMessageKey) => {
@@ -186,11 +187,6 @@ export class WhatsAppChannel implements Channel {
       } else if (connection === 'open') {
         this.connected = true;
         logger.info('Connected to WhatsApp');
-
-        // Announce availability so WhatsApp relays subsequent presence updates (typing indicators)
-        this.sock.sendPresenceUpdate('available').catch((err) => {
-          logger.warn({ err }, 'Failed to send presence update');
-        });
 
         // Build LID to phone mapping from auth state for self-chat translation
         if (this.sock.user) {


### PR DESCRIPTION
## Summary

- Set `markOnlineOnConnect: false` in `makeWASocket()` so Baileys sends `unavailable` presence on connect instead of `available`
- Remove the explicit `sendPresenceUpdate('available')` call that contradicted this setting
- Add unit test verifying `markOnlineOnConnect: false` is passed

Closes #90

## Test plan

- [x] `npm run build` — clean compile
- [x] `npm test` — 288/288 pass
- [x] Restart NanoClaw, confirm connection succeeds
- [x] Regular WhatsApp notifications arrive on phone
- [ ] No "Finished syncing" notification after reconnect
- [x] Typing indicators work in DMs and groups

🤖 Generated with [Claude Code](https://claude.com/claude-code)