### PR TITLE
fix: extract reply/quoted message context from WhatsApp

### DIFF
--- a/src/channels/whatsapp.ts
+++ b/src/channels/whatsapp.ts
@@ -317,6 +317,45 @@ export class WhatsAppChannel implements Channel {
               ? fromMe
               : content.startsWith(`${ASSISTANT_NAME}:`);
 
+            // Extract quoted message context (reply-to)
+            const contextInfo =
+              normalized.extendedTextMessage?.contextInfo ||
+              normalized.imageMessage?.contextInfo ||
+              normalized.videoMessage?.contextInfo ||
+              normalized.documentMessage?.contextInfo ||
+              normalized.audioMessage?.contextInfo ||
+              null;
+
+            let replyToMessageId: string | undefined;
+            let replyToContent: string | undefined;
+            let replyToSenderName: string | undefined;
+
+            if (contextInfo?.stanzaId && contextInfo?.quotedMessage) {
+              replyToMessageId = contextInfo.stanzaId;
+              const quotedNorm =
+                normalizeMessageContent(contextInfo.quotedMessage) ||
+                contextInfo.quotedMessage;
+              replyToContent =
+                quotedNorm?.conversation ||
+                quotedNorm?.extendedTextMessage?.text ||
+                quotedNorm?.imageMessage?.caption ||
+                quotedNorm?.videoMessage?.caption ||
+                '';
+              // Resolve sender name for the quoted message
+              const quotedParticipant = contextInfo.participant || '';
+              if (quotedParticipant) {
+                let resolvedParticipant = quotedParticipant;
+                if (resolvedParticipant.endsWith('@lid')) {
+                  const lidUser = resolvedParticipant
+                    .split('@')[0]
+                    .split(':')[0];
+                  resolvedParticipant =
+                    this.lidToPhoneMap[lidUser] || resolvedParticipant;
+                }
+                replyToSenderName = resolvedParticipant.split('@')[0];
+              }
+            }
+
             this.opts.onMessage(chatJid, {
               id: msg.key.id || '',
               chat_jid: chatJid,
@@ -326,6 +365,9 @@ export class WhatsAppChannel implements Channel {
               timestamp,
               is_from_me: fromMe,
               is_bot_message: isBotMessage,
+              reply_to_message_id: replyToMessageId,
+              reply_to_message_content: replyToContent,
+              reply_to_sender_name: replyToSenderName,
             });
           } else if (chatJid !== rawJid) {
             // LID translation produced a JID that doesn't match any registered group

--- a/src/channels/whatsapp.ts
+++ b/src/channels/whatsapp.ts
@@ -330,8 +330,13 @@ export class WhatsAppChannel implements Channel {
             let replyToContent: string | undefined;
             let replyToSenderName: string | undefined;
 
-            if (contextInfo?.stanzaId && contextInfo?.quotedMessage) {
+            // Set reply ID whenever stanzaId is present, even without
+            // a quoted payload (the router can render reply_to alone).
+            if (contextInfo?.stanzaId) {
               replyToMessageId = contextInfo.stanzaId;
+            }
+
+            if (contextInfo?.stanzaId && contextInfo?.quotedMessage) {
               const quotedNorm =
                 normalizeMessageContent(contextInfo.quotedMessage) ||
                 contextInfo.quotedMessage;
@@ -341,8 +346,12 @@ export class WhatsAppChannel implements Channel {
                 quotedNorm?.imageMessage?.caption ||
                 quotedNorm?.videoMessage?.caption ||
                 '';
-              // Resolve sender name for the quoted message
-              const quotedParticipant = contextInfo.participant || '';
+              // Resolve sender name for the quoted message.
+              // In groups, participant identifies who sent the quoted msg.
+              // In DMs, participant is empty — fall back to the chat JID
+              // (the other party) so the router can still emit <quoted_message>.
+              const quotedParticipant =
+                contextInfo.participant || chatJid || '';
               if (quotedParticipant) {
                 let resolvedParticipant = quotedParticipant;
                 if (resolvedParticipant.endsWith('@lid')) {


### PR DESCRIPTION
## What

Extracts `contextInfo` from incoming WhatsApp messages so the reply-to fields (`reply_to_message_id`, `reply_to_message_content`, `reply_to_sender_name`) are populated and passed to the agent.

## Why

The generic reply context infrastructure was added in ee599b9 (types, DB columns, router formatting as `<quoted_message>` XML) but the WhatsApp channel never extracted `contextInfo` from Baileys messages. Agents could not see what message was being replied to.

## How it works

Reads `contextInfo` from `extendedTextMessage`, `imageMessage`, `videoMessage`, `documentMessage`, and `audioMessage`. When a `stanzaId` and `quotedMessage` are present, extracts the quoted text and resolves the sender (including LID→phone translation for group participants).

## How it was tested

Deployed and tested on a live NanoClaw instance. Verified that replying to a message in WhatsApp now shows the quoted content in the agent's context via the existing `<quoted_message>` XML formatting.

## Change type

- [x] Fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)