### PR TITLE
Add GIF, video, and document attachment support

### DIFF
--- a/.claude/skills/add-media-attachments/SKILL.md
+++ b/.claude/skills/add-media-attachments/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: add-media-attachments
+description: Add GIF, video, and generic document attachment support for WhatsApp. Receives and sends GIFs inline, downloads videos and documents to workspace. Triggers on "add media", "gif support", "video attachments", "media attachments".
+---
+
+# Add Media Attachments
+
+Adds support for receiving and sending GIFs, videos, and generic document attachments via WhatsApp. Without this skill, GIFs and videos are silently dropped (only captions pass through), and non-PDF/HTML documents are discarded.
+
+## Prerequisites
+
+- WhatsApp channel installed (`/add-whatsapp`)
+
+## Phase 1: Pre-flight
+
+1. Check if `videoMessage` handling exists in `src/channels/whatsapp.ts` (search for `normalized?.videoMessage` in the message processing block) — skip to Phase 3 if already applied
+
+## Phase 2: Apply Code Changes
+
+### Ensure WhatsApp fork remote
+
+```bash
+git remote -v
+```
+
+If `whatsapp` is missing, add it:
+
+```bash
+git remote add whatsapp https://github.com/qwibitai/nanoclaw-whatsapp.git
+```
+
+### Merge the skill branch
+
+```bash
+git fetch whatsapp skill/media-attachments
+git merge whatsapp/skill/media-attachments || {
+  git checkout --theirs package-lock.json
+  git add package-lock.json
+  git merge --continue
+}
+```
+
+This merges in changes to `src/channels/whatsapp.ts`:
+
+**Inbound:**
+- GIF/video download: detects `videoMessage`, downloads media, saves as `.mp4`, labels as `[GIF]` or `[Video]` based on `gifPlayback` flag
+- Generic document catch-all: downloads any document type (`.csv`, `.json`, `.docx`, etc.) and saves to workspace
+
+**Outbound:**
+- `sendFile()` method with mime type mapping for common file types
+- GIF/video files sent as `video` with `gifPlayback: true` so they render inline instead of as document attachments
+
+If the merge reports conflicts, resolve them by reading the conflicted files and understanding the intent of both sides.
+
+### Validate
+
+```bash
+npm run build
+npx vitest run src/channels/whatsapp.test.ts
+```
+
+### Restart service
+
+```bash
+launchctl kickstart -k gui/$(id -u)/com.nanoclaw  # macOS
+# Linux: systemctl --user restart nanoclaw
+```
+
+## Phase 3: Verify
+
+### Test GIF receive
+
+Send a GIF in a registered WhatsApp chat. The agent should:
+1. Download the GIF to `attachments/video-*.mp4`
+2. See `[GIF: attachments/video-*.mp4 (size)]` in the message content
+3. Respond acknowledging the GIF
+
+### Test GIF send
+
+Ask the agent to send back a GIF it received. It should render as an inline GIF in WhatsApp, not as a document or `.bin` file.
+
+### Test document receive
+
+Send a non-PDF, non-HTML document (e.g. `.csv`, `.json`). The agent should download it and show `[File: attachments/filename (size)]`.
+
+### Check logs if needed
+
+```bash
+tail -f logs/nanoclaw.log | grep -iE "gif|video|document"
+```
+
+Look for:
+- `Downloaded video/GIF attachment` — successful GIF/video download
+- `Downloaded document attachment` — successful document download
+- `GIF/video sent` — successful outbound GIF
+- `Failed to download` — media download issue
+
+## Troubleshooting
+
+### GIF sent as .bin or .mp4 document
+
+The `sendFile` method must send `.gif`/`.mp4` files as `video` with `gifPlayback: true`. Check that the `sendFile()` method exists and has the GIF/video early-return path.
+
+### Agent doesn't see GIF content
+
+GIFs are saved as files — the agent sees a text reference, not the visual content. For visual understanding of images, use the `/add-image-vision` skill. GIFs and videos are file references only.

--- a/.claude/skills/add-media-attachments/SKILL.md
+++ b/.claude/skills/add-media-attachments/SKILL.md
@@ -44,7 +44,7 @@ This merges in changes to `src/channels/whatsapp.ts`:
 
 **Inbound:**
 - GIF/video download: detects `videoMessage`, downloads media, saves as `.mp4`, labels as `[GIF]` or `[Video]` based on `gifPlayback` flag
-- Generic document catch-all: downloads any document type (`.csv`, `.json`, `.docx`, etc.) and saves to workspace
+- Generic document catch-all: downloads any document type (`.csv`, `.json`, `.docx`, etc.) and saves to workspace. Skips PDFs to avoid conflicts with `/add-pdf-reader`
 
 **Outbound:**
 - `sendFile()` method with mime type mapping for common file types

--- a/src/channels/whatsapp.ts
+++ b/src/channels/whatsapp.ts
@@ -300,9 +300,12 @@ export class WhatsAppChannel implements Channel {
               );
             }
 
-            // Generic document attachment handling
-            if (normalized?.documentMessage) {
-              const docMime = normalized.documentMessage.mimetype || '';
+            // Generic document attachment handling (skip PDFs — handled by add-pdf-reader skill)
+            const docMime = normalized?.documentMessage?.mimetype || '';
+            if (
+              normalized?.documentMessage &&
+              docMime !== 'application/pdf'
+            ) {
               try {
                 const buffer = await downloadMediaMessage(msg, 'buffer', {});
                 const groupDir = path.join(GROUPS_DIR, groups[chatJid].folder);

--- a/src/channels/whatsapp.ts
+++ b/src/channels/whatsapp.ts
@@ -6,6 +6,7 @@ import {
   makeWASocket,
   Browsers,
   DisconnectReason,
+  downloadMediaMessage,
   fetchLatestWaWebVersion,
   makeCacheableSignalKeyStore,
   normalizeMessageContent,
@@ -26,6 +27,7 @@ const { proto } = createRequire(import.meta.url)('@whiskeysockets/baileys') as {
 import {
   ASSISTANT_HAS_OWN_NUMBER,
   ASSISTANT_NAME,
+  GROUPS_DIR,
   STORE_DIR,
 } from '../config.js';
 import {
@@ -298,6 +300,63 @@ export class WhatsAppChannel implements Channel {
               );
             }
 
+            // Generic document attachment handling
+            if (normalized?.documentMessage) {
+              const docMime = normalized.documentMessage.mimetype || '';
+              try {
+                const buffer = await downloadMediaMessage(msg, 'buffer', {});
+                const groupDir = path.join(GROUPS_DIR, groups[chatJid].folder);
+                const attachDir = path.join(groupDir, 'attachments');
+                fs.mkdirSync(attachDir, { recursive: true });
+                const filename = path.basename(
+                  normalized.documentMessage.fileName || `doc-${Date.now()}`,
+                );
+                const filePath = path.join(attachDir, filename);
+                fs.writeFileSync(filePath, buffer as Buffer);
+                const sizeKB = Math.round((buffer as Buffer).length / 1024);
+                const fileRef = `[File: attachments/${filename} (${sizeKB}KB)]\nThe file has been saved. Read it with: cat attachments/${filename}`;
+                const caption = normalized.documentMessage.caption || '';
+                content = caption ? `${caption}\n\n${fileRef}` : fileRef;
+                logger.info(
+                  { jid: chatJid, filename, mime: docMime },
+                  'Downloaded document attachment',
+                );
+              } catch (err) {
+                logger.warn(
+                  { err, jid: chatJid },
+                  'Failed to download document attachment',
+                );
+              }
+            }
+
+            // GIF / video attachment handling
+            if (normalized?.videoMessage) {
+              try {
+                const buffer = await downloadMediaMessage(msg, 'buffer', {});
+                const groupDir = path.join(GROUPS_DIR, groups[chatJid].folder);
+                const attachDir = path.join(groupDir, 'attachments');
+                fs.mkdirSync(attachDir, { recursive: true });
+                const isGif = normalized.videoMessage.gifPlayback === true;
+                const filename = `video-${Date.now()}.mp4`;
+                const filePath = path.join(attachDir, filename);
+                fs.writeFileSync(filePath, buffer as Buffer);
+                const sizeKB = Math.round((buffer as Buffer).length / 1024);
+                const label = isGif ? 'GIF' : 'Video';
+                const fileRef = `[${label}: attachments/${filename} (${sizeKB}KB)]`;
+                const caption = normalized.videoMessage.caption || '';
+                content = caption ? `${caption}\n\n${fileRef}` : fileRef;
+                logger.info(
+                  { jid: chatJid, filename, isGif },
+                  'Downloaded video/GIF attachment',
+                );
+              } catch (err) {
+                logger.warn(
+                  { err, jid: chatJid },
+                  'Failed to download video/GIF attachment',
+                );
+              }
+            }
+
             // Skip protocol messages with no text content (encryption keys, read receipts, etc.)
             if (!content) continue;
 
@@ -379,6 +438,65 @@ export class WhatsAppChannel implements Channel {
         { jid, err, queueSize: this.outgoingQueue.length },
         'Failed to send, message queued',
       );
+    }
+  }
+
+  async sendFile(
+    jid: string,
+    filePath: string,
+    fileName: string,
+    caption?: string,
+  ): Promise<void> {
+    if (!this.connected) {
+      logger.warn({ jid, fileName }, 'Cannot send file - not connected');
+      throw new Error('Not connected to WhatsApp');
+    }
+
+    const buffer = fs.readFileSync(filePath);
+    const ext = path.extname(fileName).toLowerCase();
+    const mimeTypes: Record<string, string> = {
+      '.pdf': 'application/pdf',
+      '.doc': 'application/msword',
+      '.docx':
+        'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+      '.xls': 'application/vnd.ms-excel',
+      '.xlsx':
+        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+      '.csv': 'text/csv',
+      '.txt': 'text/plain',
+      '.html': 'text/html',
+      '.htm': 'text/html',
+      '.png': 'image/png',
+      '.jpg': 'image/jpeg',
+      '.jpeg': 'image/jpeg',
+      '.gif': 'image/gif',
+      '.mp4': 'video/mp4',
+      '.zip': 'application/zip',
+    };
+    const mimetype = mimeTypes[ext] || 'application/octet-stream';
+
+    try {
+      // Send GIFs and MP4s as video with gifPlayback so they render inline
+      if (ext === '.gif' || ext === '.mp4') {
+        await this.sock.sendMessage(jid, {
+          video: buffer,
+          gifPlayback: true,
+          ...(caption ? { caption } : {}),
+        });
+        logger.info({ jid, fileName, size: buffer.length }, 'GIF/video sent');
+        return;
+      }
+
+      await this.sock.sendMessage(jid, {
+        document: buffer,
+        mimetype,
+        fileName,
+        ...(caption ? { caption } : {}),
+      });
+      logger.info({ jid, fileName, size: buffer.length }, 'File sent');
+    } catch (err) {
+      logger.error({ jid, fileName, err }, 'Failed to send file');
+      throw err;
     }
   }
 


### PR DESCRIPTION
## Summary
- **Inbound**: download and save `videoMessage` attachments (GIFs and videos) to group workspace, labeled `[GIF]` or `[Video]` based on `gifPlayback` flag. Add generic document catch-all for file types not handled by other skills (PDF, HTML).
- **Outbound**: add `sendFile()` method with mime type mapping. Send `.gif`/`.mp4` files as `video` with `gifPlayback: true` so they render inline instead of as document attachments (previously sent as `.bin`).
- Includes SKILL.md for `/add-media-attachments`

## Why
GIFs and videos sent via WhatsApp were silently dropped (only captions passed through). Non-PDF/HTML documents were also discarded. Outbound file sends for GIFs rendered as `.bin` or `.mp4` documents instead of inline GIFs.

## How it was tested
Tested on a live NanoClaw instance: sent GIFs, verified download to `attachments/`, confirmed agent sees `[GIF: ...]` reference, confirmed outbound GIFs render inline in WhatsApp.

## Change type
- [x] Feature skill

🤖 Generated with [Claude Code](https://claude.com/claude-code)