### PR TITLE
feat(whatsapp): add document/PDF sending via IPC

### DIFF
--- a/src/channels/whatsapp.ts
+++ b/src/channels/whatsapp.ts
@@ -382,6 +382,38 @@ export class WhatsAppChannel implements Channel {
     }
   }
 
+  async sendDocument(
+    jid: string,
+    base64: string,
+    mimetype: string,
+    filename: string,
+    caption = '',
+  ): Promise<void> {
+    if (!this.connected) {
+      logger.warn({ jid, filename }, 'WA disconnected, cannot send document');
+      throw new Error('WhatsApp disconnected');
+    }
+    try {
+      const sent = await this.sock.sendMessage(jid, {
+        document: Buffer.from(base64, 'base64'),
+        mimetype,
+        fileName: filename,
+        caption,
+      });
+      if (sent?.key?.id && sent.message) {
+        this.sentMessageCache.set(sent.key.id, sent.message);
+        if (this.sentMessageCache.size > 256) {
+          const oldest = this.sentMessageCache.keys().next().value!;
+          this.sentMessageCache.delete(oldest);
+        }
+      }
+      logger.info({ jid, filename, bytes: base64.length }, 'Document sent');
+    } catch (err) {
+      logger.warn({ jid, filename, err }, 'Failed to send document');
+      throw err;
+    }
+  }
+
   isConnected(): boolean {
     return this.connected;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,7 +49,7 @@ import {
 import { GroupQueue } from './group-queue.js';
 import { resolveGroupFolderPath } from './group-folder.js';
 import { startIpcWatcher } from './ipc.js';
-import { findChannel, formatMessages, formatOutbound } from './router.js';
+import { findChannel, formatMessages, formatOutbound, routeOutboundDocument } from './router.js';
 import {
   restoreRemoteControl,
   startRemoteControl,
@@ -717,6 +717,8 @@ async function main(): Promise<void> {
       if (!channel) throw new Error(`No channel for JID: ${jid}`);
       return channel.sendMessage(jid, text);
     },
+    sendDocument: (jid, base64, mimetype, filename, caption) =>
+      routeOutboundDocument(channels, jid, base64, mimetype, filename, caption),
     registeredGroups: () => registeredGroups,
     registerGroup,
     syncGroups: async (force: boolean) => {

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -12,6 +12,7 @@ import { RegisteredGroup } from './types.js';
 
 export interface IpcDeps {
   sendMessage: (jid: string, text: string) => Promise<void>;
+  sendDocument?: (jid: string, base64: string, mimetype: string, filename: string, caption?: string) => Promise<void>;
   registeredGroups: () => Record<string, RegisteredGroup>;
   registerGroup: (jid: string, group: RegisteredGroup) => void;
   syncGroups: (force: boolean) => Promise<void>;
@@ -90,6 +91,33 @@ export function startIpcWatcher(deps: IpcDeps): void {
                   logger.warn(
                     { chatJid: data.chatJid, sourceGroup },
                     'Unauthorized IPC message attempt blocked',
+                  );
+                }
+              } else if (
+                data.type === 'send_document' &&
+                data.chatJid &&
+                data.base64 &&
+                data.mimetype &&
+                data.filename
+              ) {
+                const targetGroup = registeredGroups[data.chatJid];
+                if (
+                  isMain ||
+                  (targetGroup && targetGroup.folder === sourceGroup)
+                ) {
+                  if (!deps.sendDocument) {
+                    logger.warn({ chatJid: data.chatJid }, 'sendDocument not available on this channel');
+                  } else {
+                    await deps.sendDocument(data.chatJid, data.base64, data.mimetype, data.filename, data.caption);
+                    logger.info(
+                      { chatJid: data.chatJid, filename: data.filename, sourceGroup },
+                      'IPC document sent',
+                    );
+                  }
+                } else {
+                  logger.warn(
+                    { chatJid: data.chatJid, sourceGroup },
+                    'Unauthorized IPC send_document attempt blocked',
                   );
                 }
               }

--- a/src/router.ts
+++ b/src/router.ts
@@ -51,6 +51,20 @@ export function routeOutbound(
   return channel.sendMessage(jid, text);
 }
 
+export function routeOutboundDocument(
+  channels: Channel[],
+  jid: string,
+  base64: string,
+  mimetype: string,
+  filename: string,
+  caption?: string,
+): Promise<void> {
+  const channel = channels.find((c) => c.ownsJid(jid) && c.isConnected());
+  if (!channel) throw new Error(`No channel for JID: ${jid}`);
+  if (!channel.sendDocument) throw new Error(`Channel ${channel.name} does not support document sending`);
+  return channel.sendDocument(jid, base64, mimetype, filename, caption);
+}
+
 export function findChannel(
   channels: Channel[],
   jid: string,

--- a/src/types.ts
+++ b/src/types.ts
@@ -88,6 +88,7 @@ export interface Channel {
   name: string;
   connect(): Promise<void>;
   sendMessage(jid: string, text: string): Promise<void>;
+  sendDocument?(jid: string, base64: string, mimetype: string, filename: string, caption?: string): Promise<void>;
   isConnected(): boolean;
   ownsJid(jid: string): boolean;
   disconnect(): Promise<void>;


### PR DESCRIPTION
## What

Agents can now send binary documents (PDFs, images, etc.) over WhatsApp by writing a `send_document` IPC message with a base64 payload.

- Channel interface: add optional `sendDocument()`
- `WhatsAppChannel`: implement `sendDocument()` via a Baileys document message
- router: add `routeOutboundDocument()` routing helper
- ipc: handle the `send_document` IPC type with the same auth rules as `send` messages
- index: wire `sendDocument` into `IpcDeps`

## IPC payload

```json
{ "type": "send_document", "chatJid": "...", "base64": "...", "mimetype": "application/pdf", "filename": "report.pdf", "caption": "optional" }
```

Unauthorized senders (source group ≠ target group, non-main) are blocked and logged, mirroring the existing `send` auth rules.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)
